### PR TITLE
Allow AES-KW algorithm in context

### DIFF
--- a/cwt/utils.py
+++ b/cwt/utils.py
@@ -6,6 +6,7 @@ import cbor2
 
 from .const import (
     COSE_ALGORITHMS_CEK,
+    COSE_ALGORITHMS_KEY_WRAP,
     COSE_ALGORITHMS_MAC,
     COSE_ALGORITHMS_SYMMETRIC,
     COSE_HEADER_PARAMETERS,
@@ -121,7 +122,7 @@ def to_cis(context: Dict[str, Any], recipient_alg: Optional[int] = None) -> List
     if "alg" not in context:
         raise ValueError("alg not found.")
     # if context["alg"] not in COSE_NAMED_ALGORITHMS_SUPPORTED:
-    if context["alg"] not in COSE_ALGORITHMS_CEK and context["alg"] not in COSE_ALGORITHMS_MAC:
+    if context["alg"] not in COSE_ALGORITHMS_CEK and context["alg"] not in COSE_ALGORITHMS_MAC and context["alg"] not in COSE_ALGORITHMS_KEY_WRAP:
         raise ValueError(f'Unsupported or unknown alg for context information: {context["alg"]}.')
     alg = COSE_NAMED_ALGORITHMS_SUPPORTED[context["alg"]]
     res.append(alg)

--- a/cwt/utils.py
+++ b/cwt/utils.py
@@ -122,7 +122,11 @@ def to_cis(context: Dict[str, Any], recipient_alg: Optional[int] = None) -> List
     if "alg" not in context:
         raise ValueError("alg not found.")
     # if context["alg"] not in COSE_NAMED_ALGORITHMS_SUPPORTED:
-    if context["alg"] not in COSE_ALGORITHMS_CEK and context["alg"] not in COSE_ALGORITHMS_MAC and context["alg"] not in COSE_ALGORITHMS_KEY_WRAP:
+    if (
+        context["alg"] not in COSE_ALGORITHMS_CEK
+        and context["alg"] not in COSE_ALGORITHMS_MAC
+        and context["alg"] not in COSE_ALGORITHMS_KEY_WRAP
+    ):
         raise ValueError(f'Unsupported or unknown alg for context information: {context["alg"]}.')
     alg = COSE_NAMED_ALGORITHMS_SUPPORTED[context["alg"]]
     res.append(alg)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,6 +72,19 @@ class TestUtils:
         )
         assert isinstance(res, list)
 
+    def test_to_cis_without_apu_apv_supp_pub_other(self):
+        res = to_cis(
+            {
+                "alg": "A128KW",
+                "supp_pub": {
+                    "key_data_length": 128,
+                    "protected": {"alg": "ECDH-ES+A128KW"},
+                    "other": "SUIT Payload Encryption",
+                },
+            }
+        )
+        assert isinstance(res, list)
+
     @pytest.mark.parametrize(
         "invalid, msg",
         [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -131,14 +131,6 @@ class TestUtils:
                 {"alg": "AES-CCM-16-64-128", "supp_pub": {"other": 123}},
                 "supp_pub.other should be str.",
             ),
-            (
-                {"alg": "A128KW"},
-                "Unsupported or unknown alg for context information: A128KW.",
-            ),
-            (
-                {"alg": "A128KW", "supp_pub": {}},
-                "Unsupported or unknown alg for context information: A128KW.",
-            ),
         ],
     )
     def test_to_cis_with_invalid_args(self, invalid, msg):


### PR DESCRIPTION
[Section 5.2 of RFC 9053](https://datatracker.ietf.org/doc/html/rfc9053#section-5.2-7.2) seems to allow us to assign A128KW, A192KW and A256KW.