### PR TITLE
Add ECDH-ES+AES-KW test

### DIFF
--- a/cwt/cose.py
+++ b/cwt/cose.py
@@ -662,6 +662,8 @@ class COSE(CBORProcessor):
                 return 0  # Encrypt
             if recipients[0].context[0] in COSE_ALGORITHMS_HPKE.values():
                 return 0  # Encrypt
+            if recipients[0].context[0] in COSE_ALGORITHMS_KEY_WRAP.values():
+                return 0  # Encrypt
             if recipients[0].context[0] in COSE_ALGORITHMS_MAC.values():
                 return 1  # MAC
             raise ValueError(f"Invalid alg in recipients' context information: {recipients[0]._context[0]}.")

--- a/tests/test_recipient.py
+++ b/tests/test_recipient.py
@@ -958,3 +958,72 @@ class TestRecipients:
         )
         recipient = COSE.new()
         assert b"This is the content." == recipient.decode(encoded, [rsk1, rsk2])
+
+    @pytest.mark.parametrize(
+        "key_agreement_alg, key_agreement_alg_id, kw_alg, enc_alg",
+        [
+            ("ECDH-ES+A128KW", -29, "A128KW", "A128CTR"),
+            ("ECDH-ES+A192KW", -30, "A192KW", "A192CTR"),
+            ("ECDH-ES+A256KW", -31, "A256KW", "A256CTR"),
+            ("ECDH-ES+A128KW", -29, "A128KW", "A128CBC"),
+            ("ECDH-ES+A192KW", -30, "A192KW", "A192CBC"),
+            ("ECDH-ES+A256KW", -31, "A256KW", "A256CBC"),
+        ],
+    )
+    def test_recipients_ecdh_es(self, key_agreement_alg, key_agreement_alg_id, kw_alg, enc_alg):
+        enc_key = COSEKey.from_symmetric_key(alg=enc_alg)
+        context = {
+            "alg": kw_alg,
+            "supp_pub": {
+                "key_data_length": len(enc_key.key) * 8,
+                "protected": {1: key_agreement_alg_id},
+            },
+        }
+
+        # The sender side:
+        rsk1 = COSEKey.from_jwk(
+            {
+                "kty": "EC",
+                "kid": "01",
+                "crv": "P-256",
+                "x": "usWxHK2PmfnHKwXPS54m0kTcGJ90UiglWiGahtagnv8",
+                "y": "IBOL-C3BttVivg-lSreASjpkttcsz-1rb7btKLv8EX4",
+                "d": "V8kgd2ZBRuh2dgyVINBUqpPDr7BOMGcF22CQMIUHtNM",
+                "alg": key_agreement_alg,
+            }
+        )
+        rpk2 = COSEKey.from_jwk(
+            {
+                "kty": "EC",
+                # "kid": "02",
+                "crv": "P-256",
+                "x": "-eZXC6nV-xgthy8zZMCN8pcYSeE2XfWWqckA2fsxHPc",
+                "y": "BGU5soLgsu_y7GN2I3EPUXS9EZ7Sw0qif-V70JtInFI",
+            }
+        )
+        r = Recipient.new(protected={"alg": key_agreement_alg}, sender_key=rsk1, recipient_key=rpk2, context=context)
+
+        nonce = enc_key.generate_nonce()
+        sender = COSE.new()
+        encoded = sender.encode(
+            b"Hello world!",
+            enc_key,
+            protected={"alg": enc_alg},
+            unprotected={"iv": nonce},
+            recipients=[r],
+        )
+
+        # The recipient side:
+        rsk2 = COSEKey.from_jwk(
+            {
+                "kty": "EC",
+                "kid": "02",
+                "crv": "P-256",
+                "x": "-eZXC6nV-xgthy8zZMCN8pcYSeE2XfWWqckA2fsxHPc",
+                "y": "BGU5soLgsu_y7GN2I3EPUXS9EZ7Sw0qif-V70JtInFI",
+                "d": "kwibx3gas6Kz1V2fyQHKSnr-ybflddSjN0eOnbmLmyo",
+                "alg": key_agreement_alg,
+            }
+        )
+        recipient = COSE.new()
+        assert b"Hello world!" == recipient.decode(encoded, rsk2, context)


### PR DESCRIPTION
This PR adds ECDH-ES+AES-KW key agreement and {AES-CTR, AES-CBC} encryption test.

8106acb9c8ebac6bfc17bc09032a928a20af6697 is related to #439 .
It is required to be applied, otherwise `sender.encode()` causes an error `ValueError: Invalid alg in recipients' context information: -3.`