### PR TITLE
Generate zero-length protected header for non AEAD

### DIFF
--- a/cwt/const.py
+++ b/cwt/const.py
@@ -118,14 +118,9 @@ COSE_KEY_OPERATION_VALUES = {
     "verifyMAC": 10,  # JWK-like lowerCamelCase
 }
 
-# COSE Algorithms for Content Encryption Key (CEK).
-COSE_ALGORITHMS_CEK = {
-    "A128CTR": -65534,  # AES-CTR mode w/ 128-bit key (Deprecated)
-    "A192CTR": -65533,  # AES-CTR mode w/ 192-bit key (Deprecated)
-    "A256CTR": -65532,  # AES-CTR mode w/ 256-bit key (Deprecated)
-    "A128CBC": -65531,  # AES-CBC mode w/ 128-bit key (Deprecated)
-    "A192CBC": -65530,  # AES-CBC mode w/ 192-bit key (Deprecated)
-    "A256CBC": -65529,  # AES-CBC mode w/ 256-bit key (Deprecated)
+
+# COSE AEAD Algorithms
+COSE_ALGORITHMS_CEK_AEAD = {
     "A128GCM": 1,  # AES-GCM mode w/ 128-bit key, 128-bit tag
     "A192GCM": 2,  # AES-GCM mode w/ 192-bit key, 128-bit tag
     "A256GCM": 3,  # AES-GCM mode w/ 256-bit key, 128-bit tag
@@ -139,6 +134,22 @@ COSE_ALGORITHMS_CEK = {
     "AES-CCM-64-128-128": 32,  # AES-CCM mode 128-bit key, 128-bit tag, 7-byte nonce
     "AES-CCM-64-128-256": 33,  # AES-CCM mode 256-bit key, 128-bit tag, 7-byte nonce
     # etc.
+}
+
+# COSE non AEAD Algorithms defined in RFC9459
+COSE_ALGORITHMS_CEK_NON_AEAD = {
+    "A128CTR": -65534,  # AES-CTR mode w/ 128-bit key (Deprecated)
+    "A192CTR": -65533,  # AES-CTR mode w/ 192-bit key (Deprecated)
+    "A256CTR": -65532,  # AES-CTR mode w/ 256-bit key (Deprecated)
+    "A128CBC": -65531,  # AES-CBC mode w/ 128-bit key (Deprecated)
+    "A192CBC": -65530,  # AES-CBC mode w/ 192-bit key (Deprecated)
+    "A256CBC": -65529,  # AES-CBC mode w/ 256-bit key (Deprecated)
+}
+
+# COSE Algorithms for Content Encryption Key (CEK).
+COSE_ALGORITHMS_CEK = {
+    **COSE_ALGORITHMS_CEK_AEAD,
+    **COSE_ALGORITHMS_CEK_NON_AEAD,
 }
 
 COSE_KEY_LEN = {

--- a/cwt/cose.py
+++ b/cwt/cose.py
@@ -393,7 +393,7 @@ class COSE(CBORProcessor):
         # if not isinstance(unprotected, dict):
         #     raise ValueError("unprotected header should be dict.")
         p, u = self._decode_headers(data.value[0], data.value[1])
-        alg = self._get_alg(p)
+        alg = p[1] if 1 in p else u.get(1, 0)
 
         err: Exception = ValueError("key is not found.")
 

--- a/cwt/cose.py
+++ b/cwt/cose.py
@@ -549,7 +549,10 @@ class COSE(CBORProcessor):
         u = to_cose_header(unprotected)
         if key is not None:
             if self._alg_auto_inclusion:
-                p[1] = key.alg
+                if key.alg in COSE_ALGORITHMS_CEK_NON_AEAD.values():
+                    u[1] = key.alg
+                else:
+                    p[1] = key.alg
             if self._kid_auto_inclusion and key.kid:
                 u[4] = key.kid
 

--- a/tests/test_recipient.py
+++ b/tests/test_recipient.py
@@ -832,13 +832,13 @@ class TestRecipients:
                 "y": "BGU5soLgsu_y7GN2I3EPUXS9EZ7Sw0qif-V70JtInFI",
             }
         )
-        r = Recipient.new(protected={1: 35}, recipient_key=rpk)
+        r = Recipient.new(unprotected={1: 35}, recipient_key=rpk)
         r.encode(enc_key.key)
         sender = COSE.new()
         encoded = sender.encode_and_encrypt(
             b"This is the content.",
             enc_key,
-            protected={"alg": enc_alg},
+            unprotected={"alg": enc_alg},
             recipients=[r],
         )
         recipient = COSE.new()
@@ -861,7 +861,7 @@ class TestRecipients:
             "alg": kw_alg,
             "supp_pub": {
                 "key_data_length": len(enc_key.key) * 8,
-                "protected": {1: key_agreement_alg_id},
+                "protected": {},
             },
         }
 
@@ -886,15 +886,15 @@ class TestRecipients:
                 "y": "BGU5soLgsu_y7GN2I3EPUXS9EZ7Sw0qif-V70JtInFI",
             }
         )
-        r = Recipient.new(protected={"alg": key_agreement_alg}, sender_key=rsk1, recipient_key=rpk2, context=context)
+        r = Recipient.new(unprotected={"alg": key_agreement_alg}, sender_key=rsk1, recipient_key=rpk2, context=context)
 
         nonce = enc_key.generate_nonce()
         sender = COSE.new()
         encoded = sender.encode(
             b"Hello world!",
             enc_key,
-            protected={"alg": enc_alg},
-            unprotected={"iv": nonce},
+            protected={},
+            unprotected={"alg": enc_alg, "iv": nonce},
             recipients=[r],
         )
 


### PR DESCRIPTION
Resolves #462 by
- prohibiting non zero-length protected header for non-AEAD while encoding
- getting algorithm id also from unprotected header while decoding


After this PR is merged
```python3
from cwt import COSE, COSEKey, Recipient

plaintext = b"This is the content."
cek = COSEKey.from_symmetric_key(alg="A128CBC")
kek = COSEKey.from_symmetric_key(alg="A128KW")
r = Recipient.new(unprotected={"alg": "A128KW"}, sender_key=kek)
sender = COSE.new()
encoded = sender.encode_and_encrypt(
    plaintext,
    cek,
    protected={
        "alg": "A128CBC",
    },
    unprotected={
        "iv": cek.generate_nonce(),
    },
    recipients=[r],
)
```
cause an ValueError, and it should be
```python3
from cwt import COSE, COSEKey, Recipient

plaintext = b"This is the content."
cek = COSEKey.from_symmetric_key(alg="A128CBC")
kek = COSEKey.from_symmetric_key(alg="A128KW")
r = Recipient.new(unprotected={"alg": "A128KW"}, sender_key=kek)
sender = COSE.new()
encoded = sender.encode_and_encrypt(
    plaintext,
    cek,
    protected={},
    unprotected={
        "alg": "A128CBC",
        "iv": cek.generate_nonce(),
    },
    recipients=[r],
)
```