### PR TITLE
Accept zero length map protected header

### DIFF
--- a/cwt/cose.py
+++ b/cwt/cose.py
@@ -400,7 +400,7 @@ class COSE(CBORProcessor):
         # Encrypt0
         if data.tag == 16:
             kid = self._get_kid(p, u)
-            aad = self._dumps(["Encrypt0", data.value[0], external_aad])
+            aad = self._dumps(["Encrypt0", data.value[0] if len(p) > 0 else b"", external_aad])
             nonce = u.get(5, None)
             if kid:
                 for _, k in enumerate(keys):
@@ -435,7 +435,7 @@ class COSE(CBORProcessor):
         # MAC0
         if data.tag == 17:
             kid = self._get_kid(p, u)
-            msg = self._dumps(["MAC0", data.value[0], external_aad, payload])
+            msg = self._dumps(["MAC0", data.value[0] if len(p) > 0 else b"", external_aad, payload])
             if kid:
                 for _, k in enumerate(keys):
                     if k.kid != kid:
@@ -456,7 +456,7 @@ class COSE(CBORProcessor):
 
         # MAC
         if data.tag == 97:
-            to_be_maced = self._dumps(["MAC", data.value[0], external_aad, payload])
+            to_be_maced = self._dumps(["MAC", data.value[0] if len(p) > 0 else b"", external_aad, payload])
             rs = Recipients.from_list(data.value[4], self._verify_kid, context)
             mac_auth_key = rs.derive_key(keys, alg, external_aad, "Mac_Recipient")
             mac_auth_key.verify(to_be_maced, data.value[3])
@@ -465,7 +465,7 @@ class COSE(CBORProcessor):
         # Signature1
         if data.tag == 18:
             kid = self._get_kid(p, u)
-            to_be_signed = self._dumps(["Signature1", data.value[0], external_aad, payload])
+            to_be_signed = self._dumps(["Signature1", data.value[0] if len(p) > 0 else b"", external_aad, payload])
             if kid:
                 for _, k in enumerate(keys):
                     if k.kid != kid:
@@ -510,7 +510,7 @@ class COSE(CBORProcessor):
                         to_be_signed = self._dumps(
                             [
                                 "Signature",
-                                data.value[0],
+                                data.value[0] if len(p) > 0 else b"",
                                 sig[0],
                                 external_aad,
                                 payload,
@@ -526,7 +526,7 @@ class COSE(CBORProcessor):
                     to_be_signed = self._dumps(
                         [
                             "Signature",
-                            data.value[0],
+                            data.value[0] if len(p) > 0 else b"",
                             sig[0],
                             external_aad,
                             payload,

--- a/tests/test_cose_sample_with_encode.py
+++ b/tests/test_cose_sample_with_encode.py
@@ -1,6 +1,7 @@
 from secrets import token_bytes
 
 import pytest
+from cbor2 import dumps, loads
 
 from cwt import COSE, COSEAlgs, COSEHeaders, COSEKey, COSEMessage, Recipient, Signer
 
@@ -967,6 +968,17 @@ class TestCOSESampleWithEncode:
             unprotected={COSEHeaders.KID: b"01"},
         )
         assert b"Hello world!" == recipient.decode(encoded3, pub_key)
+
+        # zero-length map protected header
+        encoded4 = sender.encode(
+            b"Hello world!",
+            priv_key,
+            unprotected={COSEHeaders.ALG: COSEAlgs.ES256, COSEHeaders.KID: b"01"},
+        )
+        loaded_encoded4 = loads(encoded4)
+        loaded_encoded4.value[0] = bytes.fromhex("a0")  # << {} >>
+        encoded4 = dumps(loaded_encoded4)
+        assert b"Hello world!" == recipient.decode(encoded4, pub_key)
 
     def test_cose_usage_examples_cose_signature1_countersignature(self):
         # The sender side:


### PR DESCRIPTION
Resolves #464 .

Which do you prefer
- `data.value[0]` -> `data.value[0] if len(p) > 0 else b""` every where (current PR) or
- `protected = data.value[0] if len(p) > 0 else b""` once and then `data.value[0]` -> `protected` every where ?