### PR TITLE
Add option for Deterministic encoded protected and unprotected headers

### DIFF
--- a/cwt/utils.py
+++ b/cwt/utils.py
@@ -344,3 +344,7 @@ def to_recipient_context(alg: int, u: Dict[int, Any], context: Union[List[Any], 
             else:
                 ctx[i].append(v)
     return ctx
+
+
+def sort_keys_for_deterministic_encoding(d: Dict[int, Any]) -> Dict[int, Any]:
+    return {k: v for k, v in sorted(d.items(), key=lambda kv: cbor2.dumps(kv[0]))}

--- a/tests/test_deterministic_encoding.py
+++ b/tests/test_deterministic_encoding.py
@@ -1,13 +1,14 @@
 """
 Tests for Core Deterministic Encoding.
 """
-import cbor2
 
+import cbor2
 import pytest
 
 from cwt import COSE, COSEKey
-from cwt.const import COSE_ALGORITHMS_SIGNATURE, COSE_ALGORITHMS_MAC
+from cwt.const import COSE_ALGORITHMS_MAC, COSE_ALGORITHMS_SIGNATURE
 from cwt.utils import sort_keys_for_deterministic_encoding
+
 
 class TestDeterministicEncoding:
     """
@@ -16,18 +17,18 @@ class TestDeterministicEncoding:
 
     def test_deterministically_sorted_dict(self):
         expected = {}
-        expected[0] = 0 # Reserved
-        expected[1] = 0 # alg
-        expected[4] = 0 # kid
-        expected[5] = 0 # IV
-        expected[7] = 0 # counter signature
-        expected[11] = 0 # Countersignature version 2
-        expected[12] = 0 # Countersignature0 version 2
-        expected[15] = 0 # CWT Claims
-        expected[33] = 0 # x5chain
-        expected[-1] = 0 # (max of COSE Header Algorithm Parameters resistry)
-        expected[-65536] = 0 # (min of COSE Header Algorithm Parameters resistry)
-        expected[-65537] = 0 # (max of Reserved for Private Use)
+        expected[0] = 0  # Reserved
+        expected[1] = 0  # alg
+        expected[4] = 0  # kid
+        expected[5] = 0  # IV
+        expected[7] = 0  # counter signature
+        expected[11] = 0  # Countersignature version 2
+        expected[12] = 0  # Countersignature0 version 2
+        expected[15] = 0  # CWT Claims
+        expected[33] = 0  # x5chain
+        expected[-1] = 0  # (max of COSE Header Algorithm Parameters resistry)
+        expected[-65536] = 0  # (min of COSE Header Algorithm Parameters resistry)
+        expected[-65537] = 0  # (max of Reserved for Private Use)
 
         d = {}
         d[4] = 0
@@ -59,24 +60,23 @@ class TestDeterministicEncoding:
 
         # create unsorted protected header
         p = {}
-        p["kid"] = sign_jwk["kid"] # 4
-        p["alg"] = sign_jwk["alg"] # 1
+        p["kid"] = sign_jwk["kid"]  # 4
+        p["alg"] = sign_jwk["alg"]  # 1
 
         ctx = COSE.new(deterministic_header=True)
         encoded = ctx.encode_and_sign(
-            payload=b'a',
+            payload=b"a",
             key=sign_key,
             protected=p,
         )
         encoded_p = cbor2.loads(encoded).value[0]
 
         sorted_p = {}
-        sorted_p[1] = COSE_ALGORITHMS_SIGNATURE[sign_jwk["alg"]] # -7 for ES256
-        sorted_p[4] = str.encode(sign_jwk["kid"]) # b'11'
+        sorted_p[1] = COSE_ALGORITHMS_SIGNATURE[sign_jwk["alg"]]  # -7 for ES256
+        sorted_p[4] = str.encode(sign_jwk["kid"])  # b'11'
         expected_p = cbor2.dumps(sorted_p)
 
         assert expected_p == encoded_p
-
 
     @pytest.mark.parametrize(
         "alg",
@@ -92,12 +92,12 @@ class TestDeterministicEncoding:
 
         # create unsorted protected header
         p = {}
-        p["kid"] = "01" # 4
-        p["alg"] = alg # 1
+        p["kid"] = "01"  # 4
+        p["alg"] = alg  # 1
 
         ctx = COSE.new(deterministic_header=True)
         encoded = ctx.encode_and_mac(
-            payload=b'a',
+            payload=b"a",
             key=mac_key,
             protected=p,
         )

--- a/tests/test_deterministic_encoding.py
+++ b/tests/test_deterministic_encoding.py
@@ -1,0 +1,111 @@
+"""
+Tests for Core Deterministic Encoding.
+"""
+import cbor2
+
+import pytest
+
+from cwt import COSE, COSEKey
+from cwt.const import COSE_ALGORITHMS_SIGNATURE, COSE_ALGORITHMS_MAC
+from cwt.utils import sort_keys_for_deterministic_encoding
+
+class TestDeterministicEncoding:
+    """
+    Tests for Core Deterministic Encoding
+    """
+
+    def test_deterministically_sorted_dict(self):
+        expected = {}
+        expected[0] = 0 # Reserved
+        expected[1] = 0 # alg
+        expected[4] = 0 # kid
+        expected[5] = 0 # IV
+        expected[7] = 0 # counter signature
+        expected[11] = 0 # Countersignature version 2
+        expected[12] = 0 # Countersignature0 version 2
+        expected[15] = 0 # CWT Claims
+        expected[33] = 0 # x5chain
+        expected[-1] = 0 # (max of COSE Header Algorithm Parameters resistry)
+        expected[-65536] = 0 # (min of COSE Header Algorithm Parameters resistry)
+        expected[-65537] = 0 # (max of Reserved for Private Use)
+
+        d = {}
+        d[4] = 0
+        d[-1] = 0
+        d[33] = 0
+        d[7] = 0
+        d[11] = 0
+        d[1] = 0
+        d[5] = 0
+        d[-65537] = 0
+        d[0] = 0
+        d[15] = 0
+        d[12] = 0
+        d[-65536] = 0
+
+        assert expected == sort_keys_for_deterministic_encoding(d)
+
+    def test_deterministic_cose_sign_binary(self):
+        sign_jwk = {
+            "kty": "EC",
+            "kid": "11",
+            "alg": "ES256",
+            "crv": "P-256",
+            "x": "usWxHK2PmfnHKwXPS54m0kTcGJ90UiglWiGahtagnv8",
+            "y": "IBOL-C3BttVivg-lSreASjpkttcsz-1rb7btKLv8EX4",
+            "d": "V8kgd2ZBRuh2dgyVINBUqpPDr7BOMGcF22CQMIUHtNM",
+        }
+        sign_key = COSEKey.from_jwk(sign_jwk)
+
+        # create unsorted protected header
+        p = {}
+        p["kid"] = sign_jwk["kid"] # 4
+        p["alg"] = sign_jwk["alg"] # 1
+
+        ctx = COSE.new(deterministic_header=True)
+        encoded = ctx.encode_and_sign(
+            payload=b'a',
+            key=sign_key,
+            protected=p,
+        )
+        encoded_p = cbor2.loads(encoded).value[0]
+
+        sorted_p = {}
+        sorted_p[1] = COSE_ALGORITHMS_SIGNATURE[sign_jwk["alg"]] # -7 for ES256
+        sorted_p[4] = str.encode(sign_jwk["kid"]) # b'11'
+        expected_p = cbor2.dumps(sorted_p)
+
+        assert expected_p == encoded_p
+
+
+    @pytest.mark.parametrize(
+        "alg",
+        [
+            "HMAC 256/64",
+            "HMAC 256/256",
+            "HMAC 384/384",
+            "HMAC 512/512",
+        ],
+    )
+    def test_deterministic_cose_mac_binary(self, alg):
+        mac_key = COSEKey.generate_symmetric_key(alg=alg)
+
+        # create unsorted protected header
+        p = {}
+        p["kid"] = "01" # 4
+        p["alg"] = alg # 1
+
+        ctx = COSE.new(deterministic_header=True)
+        encoded = ctx.encode_and_mac(
+            payload=b'a',
+            key=mac_key,
+            protected=p,
+        )
+        encoded_p = cbor2.loads(encoded).value[0]
+
+        sorted_p = {}
+        sorted_p[1] = COSE_ALGORITHMS_MAC[alg]
+        sorted_p[4] = str.encode("01")
+        expected_p = cbor2.dumps(sorted_p)
+
+        assert expected_p == encoded_p


### PR DESCRIPTION
Solves #573 .

This PR introduces `deterministic_header` option to COSE.new() constructor.
With this option, the headers will be deterministically encoded.
```python
import cbor2
from cwt import COSE, COSEKey

sign_key = COSEKey.from_jwk({
    "kty": "EC",
    "alg": "ES256",
    "crv": "P-256",
    "x": "usWxHK2PmfnHKwXPS54m0kTcGJ90UiglWiGahtagnv8",
    "y": "IBOL-C3BttVivg-lSreASjpkttcsz-1rb7btKLv8EX4",
    "d": "V8kgd2ZBRuh2dgyVINBUqpPDr7BOMGcF22CQMIUHtNM",
})

# UPDATED
ctx = COSE.new(alg_auto_inclusion=True, deterministic_header=True)
encoded = ctx.encode_and_sign(
    payload=b'a',
    key=sign_key,
    protected={"kid": "11"},
)
bstr_encoded_p = cbor2.loads(encoded).value[0]
encoded_p = cbor2.loads(bstr_encoded_p)
print(encoded_p)
```
displays `{1: -7, 4: b'11'}`, which is deterministically encoded.